### PR TITLE
clear user cache when using APCStorage

### DIFF
--- a/lib/APCStorage.php
+++ b/lib/APCStorage.php
@@ -54,7 +54,7 @@ class APCStorage implements StorageInterface
 	 */
 	public function clear()
 	{
-		apc_clear_cache();
+		apc_clear_cache('user');
 	}
 
 	/**


### PR DESCRIPTION
right now the `clear()` method of APCStorage only clears the system cache. this only contains cached files and not the actual content that was placed there using this API. see details here: http://php.net/manual/en/function.apc-clear-cache.php