### PR TITLE
replace deprecated Redis method call

### DIFF
--- a/lib/RedisStorage.php
+++ b/lib/RedisStorage.php
@@ -82,7 +82,7 @@ class RedisStorage implements Storage, \ArrayAccess
 	 */
 	public function eliminate($key)
 	{
-		$this->redis->delete($this->prefix . $key);
+		$this->redis->del($this->prefix . $key);
 	}
 
 	/**


### PR DESCRIPTION
`delete` call in Redis [is deprecated](https://github.com/phpredis/phpredis#del-delete-unlink), so changed it to `del`
