### PR TITLE
Fix FileStorage behavior

### DIFF
--- a/lib/FileStorage.php
+++ b/lib/FileStorage.php
@@ -112,7 +112,7 @@ class FileStorage implements Storage, \ArrayAccess
 			return;
 		}
 
-		if ($value === false || $value === null)
+		if ($value === null)
 		{
 			$this->eliminate($key);
 


### PR DESCRIPTION
This makes `FileStorage` working like other storages. I'm not sure if it was bug or feature.

**Brakes backward compatibility**.

This will also fix tests from #11.